### PR TITLE
Add support for providing extra `copts` strings.

### DIFF
--- a/m4/internal/gnulib/gnulib.BUILD
+++ b/m4/internal/gnulib/gnulib.BUILD
@@ -203,7 +203,7 @@ cc_library(
         "//conditions:default": _GNULIB_LINUX_SRCS,
     }),
     hdrs = _GNULIB_HDRS,
-    copts = _COPTS + ["-DHAVE_CONFIG_H"],
+    copts = _COPTS + ["-DHAVE_CONFIG_H"] + {GNULIB_EXTRA_COPTS},
     strip_include_prefix = "lib",
     textual_hdrs = [
         "lib/regex_internal.c",

--- a/m4/internal/gnulib/gnulib.bzl
+++ b/m4/internal/gnulib/gnulib.bzl
@@ -71,14 +71,16 @@ char *secure_getenv(char const *name);
 #endif
 """
 
-def gnulib_overlay(ctx, m4_version):
+def gnulib_overlay(ctx, m4_version, extra_copts = []):
     ctx.download_and_extract(
         url = _GNULIB_URLS,
         sha256 = _GNULIB_SHA256,
         output = "gnulib",
         stripPrefix = "gnulib-" + _GNULIB_VERSION,
     )
-    ctx.symlink(ctx.attr._gnulib_build, "gnulib/BUILD.bazel")
+    ctx.template("gnulib/BUILD.bazel", ctx.attr._gnulib_build, substitutions = {
+        "{GNULIB_EXTRA_COPTS}": str(extra_copts),
+    }, executable = False)
 
     config_header = _CONFIG_HEADER.format(
         M4_VERSION = m4_version,

--- a/m4/internal/repository.bzl
+++ b/m4/internal/repository.bzl
@@ -31,7 +31,7 @@ cc_library(
         "src/*.c",
         "src/*.h",
     ], exclude = ["src/stackovf.c"]),
-    copts = ["-DHAVE_CONFIG_H", "-UDEBUG"] + %s,
+    copts = ["-DHAVE_CONFIG_H", "-UDEBUG"] + {EXTRA_COPTS},
     visibility = ["//bin:__pkg__"],
     deps = [
         "//gnulib:config_h",
@@ -63,7 +63,7 @@ def _m4_repository(ctx):
     _gnulib_overlay(ctx, m4_version = version, extra_copts = extra_copts)
 
     ctx.file("WORKSPACE", "workspace(name = {name})\n".format(name = repr(ctx.name)))
-    ctx.file("BUILD.bazel", _M4_BUILD % str(extra_copts))
+    ctx.file("BUILD.bazel", _M4_BUILD.format(EXTRA_COPTS = extra_copts))
     ctx.file("bin/BUILD.bazel", _M4_BIN_BUILD)
 
     # Let M4 v1.4.15 build with contemporary Gnulib.

--- a/m4/internal/repository.bzl
+++ b/m4/internal/repository.bzl
@@ -31,7 +31,7 @@ cc_library(
         "src/*.c",
         "src/*.h",
     ], exclude = ["src/stackovf.c"]),
-    copts = ["-DHAVE_CONFIG_H", "-UDEBUG"],
+    copts = ["-DHAVE_CONFIG_H", "-UDEBUG"] + %s,
     visibility = ["//bin:__pkg__"],
     deps = [
         "//gnulib:config_h",
@@ -59,10 +59,11 @@ def _m4_repository(ctx):
         stripPrefix = "m4-{}".format(version),
     )
 
-    _gnulib_overlay(ctx, m4_version = version)
+    extra_copts = ctx.attr.extra_copts
+    _gnulib_overlay(ctx, m4_version = version, extra_copts = extra_copts)
 
     ctx.file("WORKSPACE", "workspace(name = {name})\n".format(name = repr(ctx.name)))
-    ctx.file("BUILD.bazel", _M4_BUILD)
+    ctx.file("BUILD.bazel", _M4_BUILD % str(extra_copts))
     ctx.file("bin/BUILD.bazel", _M4_BIN_BUILD)
 
     # Let M4 v1.4.15 build with contemporary Gnulib.
@@ -129,6 +130,7 @@ m4_repository = repository_rule(
     _m4_repository,
     attrs = {
         "version": attr.string(mandatory = True),
+        "extra_copts": attr.string_list(),
         "_gnulib_build": attr.label(
             default = "@rules_m4//m4/internal:gnulib/gnulib.BUILD",
             allow_single_file = True,

--- a/m4/m4.bzl
+++ b/m4/m4.bzl
@@ -113,12 +113,13 @@ m4 = rule(
     toolchains = [M4_TOOLCHAIN_TYPE],
 )
 
-def m4_register_toolchains(version = DEFAULT_VERSION):
+def m4_register_toolchains(version = DEFAULT_VERSION, extra_copts = []):
     check_version(version)
     repo_name = "m4_v{}".format(version)
     if repo_name not in native.existing_rules().keys():
         m4_repository(
             name = repo_name,
             version = version,
+            extra_copts = extra_copts,
         )
     native.register_toolchains("@rules_m4//m4/toolchains:v{}".format(version))


### PR DESCRIPTION
This is important for users with toolchains that will produce
significant warnings when building. We could try to guess at what flags
would silence these warnings (the same way the current code does for
MSVC), but on non-Windows platforms there are multiple different
compilers and compiler versions all with different warning flags.

Instead, simply provide a way for the caller to thread their own flags
through. They can in turn build whatever compiler detection logic is
desired.

It would be possible to just turn off warnings in a blanket way by
passing the flag `-w` on all non-Windows builds. On one hand, this is
a bit simpler. However, it seems rather inelegant and doesn't seem very
sustainable. As an example of where I expect this will break down is for
folks using Clang on Windows.

Happy to have other suggestions for how to configure this -- I don't
claim to be a Bazel expert here.

I'd like to send similar patches for `flex` and `bison` rules as well,
but want to get the pattern worked out here.