### PR TITLE
Buildfix OpenBSD.

### DIFF
--- a/m4/internal/gnulib/config-openbsd.h
+++ b/m4/internal/gnulib/config-openbsd.h
@@ -133,7 +133,7 @@ extern char **environ;
 #define HAVE_SIGINTERRUPT 1
 #define HAVE_SIGSET_T 1
 #define HAVE_SIG_ATOMIC_T 1
-#define HAVE_SNPRINTF 1
+#define HAVE_SNPRINTF 0
 #define HAVE_SNPRINTF_RETVAL_C99 1
 #define HAVE_SPAWN_H 1
 #define HAVE_STACK_OVERFLOW_HANDLING 1

--- a/m4/internal/gnulib/config-openbsd.h
+++ b/m4/internal/gnulib/config-openbsd.h
@@ -35,8 +35,7 @@ extern char **environ;
 #define GNULIB_SIGPIPE 1
 #define GNULIB_SNPRINTF 1
 #define GNULIB_STRERROR 1
-#define HAVE_ALLOCA 0
-#define HAVE_ALLOCA_H 0
+#define HAVE_ALLOCA 1
 #define HAVE_BTOWC 1
 #define HAVE_CANONICALIZE_FILE_NAME 1
 #define HAVE_DECL_ALARM 1
@@ -69,11 +68,9 @@ extern char **environ;
 #define HAVE_DECL_SYS_SIGLIST 1
 #define HAVE_DECL__SNPRINTF 0
 #define HAVE_DECL___ARGV 0
-#define HAVE_DECL___FPENDING 1
 #define HAVE_DUP2 1
 #define HAVE_ENVIRON_DECL 1
 #define HAVE_FCNTL 1
-#define HAVE_FEATURES_H 0
 #define HAVE_FREXPL_IN_LIBC 1
 #define HAVE_FREXP_IN_LIBC 1
 #define HAVE_FSEEKO 1
@@ -113,7 +110,6 @@ extern char **environ;
 #define HAVE_MBSTATE_T 1
 #define HAVE_MBTOWC 1
 #define HAVE_MEMORY_H 1
-#define HAVE_MEMPCPY 1
 #define HAVE_MINMAX_IN_SYS_PARAM_H 1
 #define HAVE_MKDTEMP 1
 #define HAVE_MKSTEMP 1
@@ -137,14 +133,13 @@ extern char **environ;
 #define HAVE_SIGINTERRUPT 1
 #define HAVE_SIGSET_T 1
 #define HAVE_SIG_ATOMIC_T 1
-#define HAVE_SNPRINTF 0
+#define HAVE_SNPRINTF 1
 #define HAVE_SNPRINTF_RETVAL_C99 1
 #define HAVE_SPAWN_H 1
 #define HAVE_STACK_OVERFLOW_HANDLING 1
 #define HAVE_STACK_T 1
 #define HAVE_STDINT_H 1
 #define HAVE_STDINT_H_WITH_UINTMAX 1
-#define HAVE_STDIO_EXT_H 0
 #define HAVE_STDLIB_H 1
 #define HAVE_STRCHRNUL 1
 #define HAVE_STRERROR_R 1
@@ -191,7 +186,6 @@ extern char **environ;
 #define PROMOTED_MODE_T mode_t
 #define SIGNAL_SAFE_LIST 1
 #define STDC_HEADERS 1
-#define STRERROR_R_CHAR_P 1
 #define TYPEOF_STRUCT_STAT_ST_ATIM_IS_STRUCT_TIMESPEC 1
 #define USER_LABEL_PREFIX
 #define USE_POSIX_THREADS 1

--- a/m4/internal/gnulib/config-openbsd.h
+++ b/m4/internal/gnulib/config-openbsd.h
@@ -1,0 +1,238 @@
+{GNULIB_CONFIG_HEADER}
+
+#define _GL_ATTRIBUTE_FORMAT_PRINTF(x, y)
+
+#define O_BINARY 0
+#define O_TEXT 0
+
+extern char **environ;
+
+/******************************************************************************/
+
+#define CHECK_PRINTF_SAFE 1
+#define C_LOCALE_MAYBE_EILSEQ 1
+#define DBL_EXPBIT0_BIT 20
+#define DBL_EXPBIT0_WORD 1
+#define FAULT_YIELDS_SIGBUS 0
+#define FLT_EXPBIT0_BIT 23
+#define FLT_EXPBIT0_WORD 0
+#define FUNC_FFLUSH_STDIN 0
+#define FUNC_NL_LANGINFO_YESEXPR_WORKS 1
+#define FUNC_REALPATH_WORKS 1
+#define GETTIMEOFDAY_TIMEZONE struct timezone
+#define GNULIB_CANONICALIZE_LGPL 1
+#define GNULIB_CLOSE_STREAM 1
+#define GNULIB_DIRNAME 1
+#define GNULIB_FD_SAFER_FLAG 1
+#define GNULIB_FFLUSH 1
+#define GNULIB_FILENAMECAT 1
+#define GNULIB_FOPEN_SAFER 1
+#define GNULIB_FSCANF 1
+#define GNULIB_LOCK 1
+#define GNULIB_MSVC_NOTHROW 1
+#define GNULIB_PIPE2_SAFER 1
+#define GNULIB_SCANF 1
+#define GNULIB_SIGPIPE 1
+#define GNULIB_SNPRINTF 1
+#define GNULIB_STRERROR 1
+#define HAVE_ALLOCA 0
+#define HAVE_ALLOCA_H 0
+#define HAVE_BTOWC 1
+#define HAVE_CANONICALIZE_FILE_NAME 1
+#define HAVE_DECL_ALARM 1
+#define HAVE_DECL_CLEARERR_UNLOCKED 0
+#define HAVE_DECL_FEOF_UNLOCKED 0
+#define HAVE_DECL_FERROR_UNLOCKED 1
+#define HAVE_DECL_FFLUSH_UNLOCKED 1
+#define HAVE_DECL_FGETS_UNLOCKED 1
+#define HAVE_DECL_FPURGE 0
+#define HAVE_DECL_FPUTC_UNLOCKED 0
+#define HAVE_DECL_FPUTS_UNLOCKED 0
+#define HAVE_DECL_FREAD_UNLOCKED 0
+#define HAVE_DECL_FSEEKO 1
+#define HAVE_DECL_FTELLO 1
+#define HAVE_DECL_FWRITE_UNLOCKED 0
+#define HAVE_DECL_GETCHAR_UNLOCKED 1
+#define HAVE_DECL_GETC_UNLOCKED 1
+#define HAVE_DECL_GETDTABLESIZE 1
+#define HAVE_DECL_ISBLANK 1
+#define HAVE_DECL_PROGRAM_INVOCATION_NAME 0
+#define HAVE_DECL_PROGRAM_INVOCATION_SHORT_NAME 0
+#define HAVE_DECL_PUTCHAR_UNLOCKED 1
+#define HAVE_DECL_PUTC_UNLOCKED 1
+#define HAVE_DECL_SIGALTSTACK 1
+#define HAVE_DECL_SNPRINTF 1
+#define HAVE_DECL_STRERROR_R 1
+#define HAVE_DECL_STRNDUP 1
+#define HAVE_DECL_STRNLEN 1
+#define HAVE_DECL_STRSIGNAL 1
+#define HAVE_DECL_SYS_SIGLIST 1
+#define HAVE_DECL__SNPRINTF 0
+#define HAVE_DECL___ARGV 0
+#define HAVE_DECL___FPENDING 1
+#define HAVE_DUP2 1
+#define HAVE_ENVIRON_DECL 1
+#define HAVE_FCNTL 1
+#define HAVE_FEATURES_H 0
+#define HAVE_FREXPL_IN_LIBC 1
+#define HAVE_FREXP_IN_LIBC 1
+#define HAVE_FSEEKO 1
+#define HAVE_GETCWD 1
+#define HAVE_GETDTABLESIZE 1
+#define HAVE_GETEGID 1
+#define HAVE_GETEUID 1
+#define HAVE_GETGID 1
+#define HAVE_GETOPT_H 1
+#define HAVE_GETOPT_LONG_ONLY 1
+#define HAVE_GETTIMEOFDAY 1
+#define HAVE_GETUID 1
+#define HAVE_INTMAX_T 1
+#define HAVE_INTTYPES_H 1
+#define HAVE_INTTYPES_H_WITH_UINTMAX 1
+#define HAVE_ISBLANK 1
+#define HAVE_ISNAND_IN_LIBC 1
+#define HAVE_ISNANF_IN_LIBC 1
+#define HAVE_ISNANL_IN_LIBC 1
+#define HAVE_ISWCNTRL 1
+#define HAVE_ISWCTYPE 1
+#define HAVE_LANGINFO_CODESET 1
+#define HAVE_LANGINFO_H 1
+#define HAVE_LDEXPL_IN_LIBC 1
+#define HAVE_LDEXP_IN_LIBC 1
+#define HAVE_LIBINTL_H 1
+#define HAVE_LIMITS_H 1
+#define HAVE_LINK 1
+#define HAVE_LONG_LONG_INT 1
+#define HAVE_LSTAT 1
+#define HAVE_MALLOC_H 1
+#define HAVE_MALLOC_POSIX 1
+#define HAVE_MAP_ANONYMOUS 1
+#define HAVE_MATH_H 1
+#define HAVE_MBRTOWC 1
+#define HAVE_MBSINIT 1
+#define HAVE_MBSTATE_T 1
+#define HAVE_MBTOWC 1
+#define HAVE_MEMORY_H 1
+#define HAVE_MEMPCPY 1
+#define HAVE_MINMAX_IN_SYS_PARAM_H 1
+#define HAVE_MKDTEMP 1
+#define HAVE_MKSTEMP 1
+#define HAVE_MPROTECT 1
+#define HAVE_NL_LANGINFO 1
+#define HAVE_PIPE 1
+#define HAVE_PIPE2 1
+#define HAVE_POSIX_SPAWN 1
+#define HAVE_POSIX_SPAWNATTR_T 1
+#define HAVE_POSIX_SPAWN_FILE_ACTIONS_T 1
+#define HAVE_PTHREAD_MUTEX_RECURSIVE 1
+#define HAVE_PTHREAD_RWLOCK 1
+#define HAVE_RAISE 1
+#define HAVE_RAWMEMCHR 1
+#define HAVE_READLINK 1
+#define HAVE_REALPATH 1
+#define HAVE_SECURE_GETENV 1
+#define HAVE_SETRLIMIT 1
+#define HAVE_SIGACTION 1
+#define HAVE_SIGALTSTACK 1
+#define HAVE_SIGINTERRUPT 1
+#define HAVE_SIGSET_T 1
+#define HAVE_SIG_ATOMIC_T 1
+#define HAVE_SNPRINTF 0
+#define HAVE_SNPRINTF_RETVAL_C99 1
+#define HAVE_SPAWN_H 1
+#define HAVE_STACK_OVERFLOW_HANDLING 1
+#define HAVE_STACK_T 1
+#define HAVE_STDINT_H 1
+#define HAVE_STDINT_H_WITH_UINTMAX 1
+#define HAVE_STDIO_EXT_H 0
+#define HAVE_STDLIB_H 1
+#define HAVE_STRCHRNUL 1
+#define HAVE_STRERROR_R 1
+#define HAVE_STRINGS_H 1
+#define HAVE_STRING_H 1
+#define HAVE_STRNDUP 1
+#define HAVE_STRNLEN 1
+#define HAVE_STRSIGNAL 1
+#define HAVE_STRUCT_SIGACTION_SA_SIGACTION 1
+#define HAVE_STRUCT_STAT_ST_ATIM_TV_NSEC 1
+#define HAVE_SYMLINK 1
+#define HAVE_SYS_CDEFS_H 1
+#define HAVE_SYS_MMAN_H 1
+#define HAVE_SYS_PARAM_H 1
+#define HAVE_SYS_SOCKET_H 1
+#define HAVE_SYS_STAT_H 1
+#define HAVE_SYS_TIME_H 1
+#define HAVE_SYS_TYPES_H 1
+#define HAVE_SYS_WAIT_H 1
+#define HAVE_TOWLOWER 1
+#define HAVE_UCONTEXT_H 0
+#define HAVE_UNISTD_H 1
+#define HAVE_UNSIGNED_LONG_LONG_INT 1
+#define HAVE_VAR___PROGNAME 1
+#define HAVE_VASPRINTF 1
+#define HAVE_WAITID 1
+#define HAVE_WCHAR_H 1
+#define HAVE_WCHAR_T 1
+#define HAVE_WCRTOMB 1
+#define HAVE_WCSLEN 1
+#define HAVE_WCSNLEN 1
+#define HAVE_WCTYPE_H 1
+#define HAVE_WINT_T 1
+#define HAVE_WORKING_O_NOATIME 0
+#define HAVE_WORKING_O_NOFOLLOW 1
+#define HAVE__BOOL 1
+#define HAVE___BUILTIN_EXPECT 1
+#define HAVE___FPURGE 1
+#define HAVE___FREADING 1
+#define HAVE___INLINE 1
+#define LSTAT_FOLLOWS_SLASHED_SYMLINK 1
+#define MALLOC_0_IS_NONNULL 1
+# define __USE_MINGW_ANSI_STDIO 1
+#define PROMOTED_MODE_T mode_t
+#define SIGNAL_SAFE_LIST 1
+#define STDC_HEADERS 1
+#define STRERROR_R_CHAR_P 1
+#define TYPEOF_STRUCT_STAT_ST_ATIM_IS_STRUCT_TIMESPEC 1
+#define USER_LABEL_PREFIX
+#define USE_POSIX_THREADS 1
+#define USE_POSIX_THREADS_WEAK 1
+# define _ALL_SOURCE 1
+# define _DARWIN_C_SOURCE 1
+# define _GNU_SOURCE 1
+# define _NETBSD_SOURCE 1
+# define _OPENBSD_SOURCE 1
+# define _POSIX_PTHREAD_SEMANTICS 1
+# define __STDC_WANT_IEC_60559_ATTRIBS_EXT__ 1
+# define __STDC_WANT_IEC_60559_BFP_EXT__ 1
+# define __STDC_WANT_IEC_60559_DFP_EXT__ 1
+# define __STDC_WANT_IEC_60559_FUNCS_EXT__ 1
+# define __STDC_WANT_IEC_60559_TYPES_EXT__ 1
+# define __STDC_WANT_LIB_EXT2__ 1
+# define __STDC_WANT_MATH_SPEC_FUNCS__ 1
+# define _TANDEM_SOURCE 1
+# define _HPUX_ALT_XOPEN_SOCKET_API 1
+# define __EXTENSIONS__ 1
+#define USE_UNLOCKED_IO 0
+#define _DARWIN_USE_64_BIT_INODE 1
+#define _NETBSD_SOURCE 1
+#define _REGEX_INCLUDE_LIMITS_H 1
+#define _REGEX_LARGE_OFFSETS 1
+#define _USE_STD_STAT 1
+#define re_comp rpl_re_comp
+#define re_compile_fastmap rpl_re_compile_fastmap
+#define re_compile_pattern rpl_re_compile_pattern
+#define re_exec rpl_re_exec
+#define re_match rpl_re_match
+#define re_match_2 rpl_re_match_2
+#define re_search rpl_re_search
+#define re_search_2 rpl_re_search_2
+#define re_set_registers rpl_re_set_registers
+#define re_set_syntax rpl_re_set_syntax
+#define re_syntax_options rpl_re_syntax_options
+#define regcomp rpl_regcomp
+#define regerror rpl_regerror
+#define regexec rpl_regexec
+#define regfree rpl_regfree
+#define restrict __restrict
+
+{GNULIB_CONFIG_FOOTER}

--- a/m4/internal/gnulib/gnulib.BUILD
+++ b/m4/internal/gnulib/gnulib.BUILD
@@ -23,6 +23,9 @@ cc_library(
         "@bazel_tools//src/conditions:windows": [
             "config-windows/config.h",
         ],
+        "@bazel_tools//src/conditions:openbsd": [
+            "config-openbsd/config.h",
+        ],
         "//conditions:default": [
             "config-linux/config.h",
         ],
@@ -33,6 +36,9 @@ cc_library(
         ],
         "@bazel_tools//src/conditions:windows": [
             "config-windows",
+        ],
+        "@bazel_tools//src/conditions:openbsd": [
+            "config-openbsd",
         ],
         "//conditions:default": [
             "config-linux",

--- a/m4/internal/gnulib/gnulib.BUILD
+++ b/m4/internal/gnulib/gnulib.BUILD
@@ -54,6 +54,12 @@ cc_library(
     deps = [":config_h"],
 )
 
+cc_library(
+    name = "stub_alloca_h",
+    hdrs = ["stub-alloca/alloca.h"],
+    includes = ["stub-alloca"],
+)
+
 _GNULIB_HDRS = glob([
     "lib/*.h",
     "lib/glthread/*.h",
@@ -221,6 +227,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [":config_h"] + select({
         "@bazel_tools//src/conditions:windows": [":gnulib_windows_shims"],
+        "@bazel_tools//src/conditions:openbsd": [":stub_alloca_h"],
         "//conditions:default": [],
     }),
 )

--- a/m4/internal/gnulib/gnulib.bzl
+++ b/m4/internal/gnulib/gnulib.bzl
@@ -97,11 +97,23 @@ def gnulib_overlay(ctx, m4_version, extra_copts = []):
         "{GNULIB_CONFIG_HEADER}": config_header,
         "{GNULIB_CONFIG_FOOTER}": _CONFIG_FOOTER,
     }, executable = False)
+    ctx.template("gnulib/config-openbsd/config.h", ctx.attr._gnulib_config_openbsd_h, substitutions = {
+        "{GNULIB_CONFIG_HEADER}": config_header,
+        "{GNULIB_CONFIG_FOOTER}": _CONFIG_FOOTER,
+    }, executable = False)
 
     for shim in _WINDOWS_STDLIB_SHIMS:
         in_h = "gnulib/lib/{}.in.h".format(shim.replace("/", "_"))
         out_h = "gnulib/config-windows/shim-libc/gnulib/{}.h".format(shim)
         ctx.template(out_h, in_h, substitutions = _WINDOWS_AC_SUBST, executable = False)
+
+    if ctx.os.name == "openbsd":
+        ctx.template(
+            "gnulib/lib/alloca.h",
+            "gnulib/lib/alloca.in.h",
+            substitutions = {},
+            executable = False,
+        )
 
     # Older versions of M4 expect gnulib shims for exit() and strstr()
     ctx.file("gnulib/lib/exit.h", "#include <stdlib.h>")

--- a/m4/internal/gnulib/gnulib.bzl
+++ b/m4/internal/gnulib/gnulib.bzl
@@ -152,6 +152,11 @@ static const char * _replaced_get_charset_aliases (void)
     # Some platforms have alloca() but not <alloca.h>.
     ctx.file("gnulib/stub-alloca/alloca.h", "")
 
+    # Silence warning about unused variable when HAVE_SNPRINTF is defined 0.
+    ctx.template("gnulib/lib/vasnprintf.c", "gnulib/lib/vasnprintf.c", substitutions = {
+        "int flags = dp->flags;": "int flags = dp->flags; (void)flags;",
+    })
+
 _WINDOWS_STDLIB_SHIMS = [
     "alloca",
     "errno",

--- a/m4/internal/gnulib/gnulib.bzl
+++ b/m4/internal/gnulib/gnulib.bzl
@@ -107,14 +107,6 @@ def gnulib_overlay(ctx, m4_version, extra_copts = []):
         out_h = "gnulib/config-windows/shim-libc/gnulib/{}.h".format(shim)
         ctx.template(out_h, in_h, substitutions = _WINDOWS_AC_SUBST, executable = False)
 
-    if ctx.os.name == "openbsd":
-        ctx.template(
-            "gnulib/lib/alloca.h",
-            "gnulib/lib/alloca.in.h",
-            substitutions = {},
-            executable = False,
-        )
-
     # Older versions of M4 expect gnulib shims for exit() and strstr()
     ctx.file("gnulib/lib/exit.h", "#include <stdlib.h>")
     ctx.file("gnulib/lib/strstr.h", "#include <string.h>")
@@ -156,6 +148,9 @@ static const char * _replaced_get_charset_aliases (void)
     ctx.template("gnulib/lib/c-stack.c", "gnulib/lib/c-stack.c", substitutions = {
         "SIGSTKSZ": "GNULIB_SIGSTKSZ",
     })
+
+    # Some platforms have alloca() but not <alloca.h>.
+    ctx.file("gnulib/stub-alloca/alloca.h", "")
 
 _WINDOWS_STDLIB_SHIMS = [
     "alloca",

--- a/m4/internal/repository.bzl
+++ b/m4/internal/repository.bzl
@@ -146,5 +146,9 @@ m4_repository = repository_rule(
             default = "//m4/internal:gnulib/config-windows.h",
             allow_single_file = True,
         ),
+        "_gnulib_config_openbsd_h": attr.label(
+            default = "//m4/internal:gnulib/config-openbsd.h",
+            allow_single_file = True,
+        ),
     },
 )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -51,6 +51,10 @@ cc_test(
     name = "m4_test",
     srcs = ["m4_test.cc"],
     data = [":testdata"],
+    linkstatic = select({
+        "@bazel_tools//src/conditions:openbsd": True,
+        "//conditions:default": None,
+    }),
     local_defines = [
         "'EXPANSION_TEST_IN=\"" + package_name() + "/expansion_test.in\"'",
     ],


### PR DESCRIPTION
Of note, the config header is just forked from the Linux config file and
mutated until things build correctly. I didn't think it necessary to
spend too much effort to make sure the config header matches the output
from configure too much.