### PR TITLE
Add bzlmod support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,20 @@
+module(
+    name = "rules_m4",
+    version = "0.2.2-bcr.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(
+    name = "googletest",
+    version = "1.11.0",
+    repo_name = "com_google_googletest",
+    dev_dependency = True,
+)
+
+initialize_m4_toolchains = use_extension(
+    "@rules_m4//m4:extensions.bzl",
+    "initialize_m4_toolchains",
+)
+initialize_m4_toolchains.configure(extra_copts = [])
+use_repo(initialize_m4_toolchains, "m4_v1.4.18")
+register_toolchains("@rules_m4//m4/toolchains:v1.4.18")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,20 +1,53 @@
 module(
     name = "rules_m4",
-    version = "0.2.2-bcr.0",
     compatibility_level = 1,
+    version = "0.2.2-bcr.0",
 )
 
 bazel_dep(
     name = "googletest",
-    version = "1.11.0",
-    repo_name = "com_google_googletest",
     dev_dependency = True,
+    repo_name = "com_google_googletest",
+    version = "1.11.0",
 )
 
-initialize_m4_toolchains = use_extension(
-    "@rules_m4//m4:extensions.bzl",
-    "initialize_m4_toolchains",
-)
-initialize_m4_toolchains.configure(extra_copts = [])
-use_repo(initialize_m4_toolchains, "m4_v1.4.18")
-register_toolchains("@rules_m4//m4/toolchains:v1.4.18")
+m4 = use_extension("@rules_m4//m4:extensions.bzl", "m4_extension")
+
+SUPPORTED_VERSIONS = [
+    "1.4.18",
+    "1.4.17",
+    "1.4.16",
+    "1.4.15",
+    "1.4.14",
+    "1.4.13",
+    "1.4.12",
+    "1.4.11",
+    "1.4.10",
+    "1.4.9",
+    "1.4.8",
+    "1.4.7",
+    "1.4.6",
+    "1.4.5",
+    "1.4.4",
+    "1.4.3",
+    "1.4.2",
+    "1.4.1",
+]
+
+[
+    m4.configure_toolchain(version = version)
+    for version in SUPPORTED_VERSIONS
+]
+
+[
+    use_repo(
+        m4,
+        "m4_v{}".format(version),
+    )
+    for version in SUPPORTED_VERSIONS
+]
+
+[
+    register_toolchains("@rules_m4//m4/toolchains:v{}".format(version))
+    for version in SUPPORTED_VERSIONS
+]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,28 @@ genrule(
 )
 ```
 
+### Bzlmod
+
+Add the following line to `MODULE.bazel`:
+
+```python
+bazel_dep(name = "rules_m4", version = "0.2.2-bcr.0")
+```
+
+Optionally, additional `copts` may be configured for the toolchain build by
+overriding the `initialize_m4_toolchains` extension. For instance, to disable
+warnings during the build:
+
+```python
+bazel_dep(name = "rules_m4", version = "0.2.2-bcr.0")
+
+initialize_m4_toolchains = use_extension(
+    "@rules_m4//m4:extensions.bzl",
+    "initialize_m4_toolchains",
+)
+initialize_m4_toolchains.configure(extra_copts = ["-w"])
+```
+
 ## Toolchains
 
 ```python

--- a/README.md
+++ b/README.md
@@ -45,17 +45,19 @@ bazel_dep(name = "rules_m4", version = "0.2.2-bcr.0")
 ```
 
 Optionally, additional `copts` may be configured for the toolchain build by
-overriding the `initialize_m4_toolchains` extension. For instance, to disable
-warnings during the build:
+overriding the `m4_extension`. For instance, to disable warnings during the
+toolchain build:
 
 ```python
 bazel_dep(name = "rules_m4", version = "0.2.2-bcr.0")
 
-initialize_m4_toolchains = use_extension(
-    "@rules_m4//m4:extensions.bzl",
-    "initialize_m4_toolchains",
-)
-initialize_m4_toolchains.configure(extra_copts = ["-w"])
+m4 = use_extension("@rules_m4//m4:extensions.bzl", "m4_extension")
+
+# Reconfigure the default toolchain.
+m4.configure_toolchain(extra_copts = ["-w"])
+
+# Reconfigure a non-default toolchain.
+m4.configure_toolchain(version = "1.4.17", extra_copts = ["-w"])
 ```
 
 ## Toolchains

--- a/m4/extensions.bzl
+++ b/m4/extensions.bzl
@@ -1,0 +1,35 @@
+load("@rules_m4//m4/internal:repository.bzl", "m4_repository")
+load("@rules_m4//m4/internal:versions.bzl", "DEFAULT_VERSION", "check_version")
+
+def _initialize_m4_toolchains_impl(module_ctx):
+    # Override extra_copts with the values in the user-specified MODULE.bazel.
+    # This corresponds to the first entry in this list. If a user does not
+    # manually configure the repo via initialize_m4_toolchain.configure, the
+    # empty default values are used.
+    extra_copts = []
+    for module in module_ctx.modules:
+        extra_copts = module.tags.configure[0].extra_copts
+        break
+
+    # Enabling non-default versions requires complicated version resolution and
+    # encapsulation of toolchains. Bzlmod users will most likely want to use the
+    # latest available version of m4 without thinking too much about it.
+    check_version(DEFAULT_VERSION)
+    repo_name = "m4_v{}".format(DEFAULT_VERSION)
+    if repo_name not in native.existing_rules().keys():
+        m4_repository(
+            name = repo_name,
+            version = DEFAULT_VERSION,
+            extra_copts = extra_copts,
+        )
+
+initialize_m4_toolchains = module_extension(
+    implementation = _initialize_m4_toolchains_impl,
+    tag_classes = {
+        "configure": tag_class(
+            attrs = {
+                "extra_copts": attr.string_list(),
+            },
+        ),
+    },
+)


### PR DESCRIPTION
Added a basic configuration for the new bzlmod module system which reduces the import of rules_m4 to a single line in a MODULE.bazel file.