### PR TITLE
Fixed incompatibility issues failing BCR dependents

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,16 +4,16 @@ buildifier:
   version: 6.1.2
   warnings: "-attr-cfg"
 tasks:
-  ubuntu_1804_gcc:
-    platform: ubuntu1804
+  ubuntu_2204_gcc:
+    platform: ubuntu2204
     environment:
       CC: gcc
     build_targets: ["//..."]
     test_targets:
       - "//..."
       - "//tests:all_versions"
-  ubuntu_1804_clang:
-    platform: ubuntu1804
+  ubuntu_2204_clang:
+    platform: ubuntu2204
     environment:
       CC: clang
     build_targets: ["//..."]
@@ -31,6 +31,6 @@ tasks:
       - "//..."
       - "//tests:all_versions"
   check_docs_match_stardoc:
-    platform: ubuntu1804
+    platform: ubuntu2204
     test_targets:
       - "//tests:docs_test"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,6 +4,9 @@ module(
     compatibility_level = 1,
 )
 
+bazel_dep(name = "rules_cc", version = "0.1.1")
+
+bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency = True)
 bazel_dep(
     name = "googletest",
     version = "1.12.1",

--- a/docs/rules_m4.md
+++ b/docs/rules_m4.md
@@ -4,13 +4,14 @@
 
 Bazel rules for the m4 macro expander.
 
-
 <a id="m4"></a>
 
 ## m4
 
 <pre>
-m4(<a href="#m4-name">name</a>, <a href="#m4-freeze_state">freeze_state</a>, <a href="#m4-m4_options">m4_options</a>, <a href="#m4-output">output</a>, <a href="#m4-reload_state">reload_state</a>, <a href="#m4-srcs">srcs</a>)
+load("@rules_m4//tools/stardoc:rules_m4_md.bzl", "m4")
+
+m4(<a href="#m4-name">name</a>, <a href="#m4-srcs">srcs</a>, <a href="#m4-freeze_state">freeze_state</a>, <a href="#m4-m4_options">m4_options</a>, <a href="#m4-output">output</a>, <a href="#m4-reload_state">reload_state</a>)
 </pre>
 
 Perform macro expansion to produce an output file.
@@ -30,18 +31,87 @@ m4(
 )
 ```
 
-
 **ATTRIBUTES**
 
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="m4-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="m4-freeze_state"></a>freeze_state |  Optional output file for GNU M4 frozen state. Must have extension <code>.m4f</code>.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  |
-| <a id="m4-m4_options"></a>m4_options |  Additional options to pass to the <code>m4</code> command.<br><br>These will be added to the command args immediately before the source files.   | List of strings | optional | <code>[]</code> |
-| <a id="m4-output"></a>output |  File to write output to. If unset, defaults to the rule name.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  |
-| <a id="m4-reload_state"></a>reload_state |  Optional input file for GNU M4 frozen state. Must have extension <code>.m4f</code>.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 | <a id="m4-srcs"></a>srcs |  List of source files to macro-expand.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+| <a id="m4-freeze_state"></a>freeze_state |  Optional output file for GNU M4 frozen state. Must have extension `.m4f`.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="m4-m4_options"></a>m4_options |  Additional options to pass to the `m4` command.<br><br>These will be added to the command args immediately before the source files.   | List of strings | optional |  `[]`  |
+| <a id="m4-output"></a>output |  File to write output to. If unset, defaults to the rule name.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="m4-reload_state"></a>reload_state |  Optional input file for GNU M4 frozen state. Must have extension `.m4f`.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+
+
+<a id="M4ToolchainInfo"></a>
+
+## M4ToolchainInfo
+
+<pre>
+load("@rules_m4//tools/stardoc:rules_m4_md.bzl", "M4ToolchainInfo")
+
+M4ToolchainInfo(<a href="#M4ToolchainInfo-all_files">all_files</a>, <a href="#M4ToolchainInfo-m4_tool">m4_tool</a>, <a href="#M4ToolchainInfo-m4_env">m4_env</a>)
+</pre>
+
+Provider for an m4 toolchain.
+
+**FIELDS**
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="M4ToolchainInfo-all_files"></a>all_files |  A `depset` containing all files comprising this m4 toolchain.    |
+| <a id="M4ToolchainInfo-m4_tool"></a>m4_tool |  A `FilesToRunProvider` for the `m4` binary.    |
+| <a id="M4ToolchainInfo-m4_env"></a>m4_env |  Additional environment variables to set when running `m4_tool`.    |
+
+
+<a id="m4_register_toolchains"></a>
+
+## m4_register_toolchains
+
+<pre>
+load("@rules_m4//tools/stardoc:rules_m4_md.bzl", "m4_register_toolchains")
+
+m4_register_toolchains(<a href="#m4_register_toolchains-version">version</a>, <a href="#m4_register_toolchains-extra_copts">extra_copts</a>)
+</pre>
+
+A helper function for m4 toolchains registration.
+
+This workspace macro will create a [`m4_repository`](#m4_repository) named
+`m4_v{version}` and register it as a Bazel toolchain.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="m4_register_toolchains-version"></a>version |  A supported version of GNU M4.   |  `"1.4.18"` |
+| <a id="m4_register_toolchains-extra_copts"></a>extra_copts |  Additional C compiler options to use when building GNU M4.   |  `[]` |
+
+
+<a id="m4_toolchain"></a>
+
+## m4_toolchain
+
+<pre>
+load("@rules_m4//tools/stardoc:rules_m4_md.bzl", "m4_toolchain")
+
+m4_toolchain(<a href="#m4_toolchain-ctx">ctx</a>)
+</pre>
+
+Returns the current [`M4ToolchainInfo`](#M4ToolchainInfo).
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="m4_toolchain-ctx"></a>ctx |  A rule context, where the rule has a toolchain dependency on [`M4_TOOLCHAIN_TYPE`](#M4_TOOLCHAIN_TYPE).   |  none |
+
+**RETURNS**
+
+An [`M4ToolchainInfo`](#M4ToolchainInfo).
 
 
 <a id="m4_repository"></a>
@@ -49,9 +119,10 @@ m4(
 ## m4_repository
 
 <pre>
+load("@rules_m4//tools/stardoc:rules_m4_md.bzl", "m4_repository")
+
 m4_repository(<a href="#m4_repository-name">name</a>, <a href="#m4_repository-extra_copts">extra_copts</a>, <a href="#m4_repository-repo_mapping">repo_mapping</a>, <a href="#m4_repository-version">version</a>)
 </pre>
-
 
 Repository rule for GNU M4.
 
@@ -68,15 +139,14 @@ m4_repository(
 )
 ```
 
-
 **ATTRIBUTES**
 
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="m4_repository-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="m4_repository-extra_copts"></a>extra_copts |  Additional C compiler options to use when building GNU M4.   | List of strings | optional | <code>[]</code> |
-| <a id="m4_repository-repo_mapping"></a>repo_mapping |  A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.&lt;p&gt;For example, an entry <code>"@foo": "@bar"</code> declares that, for any time this repository depends on <code>@foo</code> (such as a dependency on <code>@foo//some:target</code>, it should actually resolve that dependency within globally-declared <code>@bar</code> (<code>@bar//some:target</code>).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | required |  |
+| <a id="m4_repository-extra_copts"></a>extra_copts |  Additional C compiler options to use when building GNU M4.   | List of strings | optional |  `[]`  |
+| <a id="m4_repository-repo_mapping"></a>repo_mapping |  In `WORKSPACE` context only: a dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.<br><br>For example, an entry `"@foo": "@bar"` declares that, for any time this repository depends on `@foo` (such as a dependency on `@foo//some:target`, it should actually resolve that dependency within globally-declared `@bar` (`@bar//some:target`).<br><br>This attribute is _not_ supported in `MODULE.bazel` context (when invoking a repository rule inside a module extension's implementation function).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  |
 | <a id="m4_repository-version"></a>version |  A supported version of GNU M4.   | String | required |  |
 
 
@@ -85,9 +155,10 @@ m4_repository(
 ## m4_toolchain_repository
 
 <pre>
+load("@rules_m4//tools/stardoc:rules_m4_md.bzl", "m4_toolchain_repository")
+
 m4_toolchain_repository(<a href="#m4_toolchain_repository-name">name</a>, <a href="#m4_toolchain_repository-m4_repository">m4_repository</a>, <a href="#m4_toolchain_repository-repo_mapping">repo_mapping</a>)
 </pre>
-
 
 Toolchain repository rule for m4 toolchains.
 
@@ -116,79 +187,13 @@ m4_toolchain_repository(
 register_toolchains("@m4//:toolchain")
 ```
 
-
 **ATTRIBUTES**
 
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="m4_toolchain_repository-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="m4_toolchain_repository-m4_repository"></a>m4_repository |  The name of an [<code>m4_repository</code>](#m4_repository).   | String | required |  |
-| <a id="m4_toolchain_repository-repo_mapping"></a>repo_mapping |  A dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.&lt;p&gt;For example, an entry <code>"@foo": "@bar"</code> declares that, for any time this repository depends on <code>@foo</code> (such as a dependency on <code>@foo//some:target</code>, it should actually resolve that dependency within globally-declared <code>@bar</code> (<code>@bar//some:target</code>).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | required |  |
-
-
-<a id="M4ToolchainInfo"></a>
-
-## M4ToolchainInfo
-
-<pre>
-M4ToolchainInfo(<a href="#M4ToolchainInfo-all_files">all_files</a>, <a href="#M4ToolchainInfo-m4_tool">m4_tool</a>, <a href="#M4ToolchainInfo-m4_env">m4_env</a>)
-</pre>
-
-Provider for an m4 toolchain.
-
-**FIELDS**
-
-
-| Name  | Description |
-| :------------- | :------------- |
-| <a id="M4ToolchainInfo-all_files"></a>all_files |  A <code>depset</code> containing all files comprising this m4 toolchain.    |
-| <a id="M4ToolchainInfo-m4_tool"></a>m4_tool |  A <code>FilesToRunProvider</code> for the <code>m4</code> binary.    |
-| <a id="M4ToolchainInfo-m4_env"></a>m4_env |  Additional environment variables to set when running <code>m4_tool</code>.    |
-
-
-<a id="m4_register_toolchains"></a>
-
-## m4_register_toolchains
-
-<pre>
-m4_register_toolchains(<a href="#m4_register_toolchains-version">version</a>, <a href="#m4_register_toolchains-extra_copts">extra_copts</a>)
-</pre>
-
-A helper function for m4 toolchains registration.
-
-This workspace macro will create a [`m4_repository`](#m4_repository) named
-`m4_v{version}` and register it as a Bazel toolchain.
-
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="m4_register_toolchains-version"></a>version |  A supported version of GNU M4.   |  <code>"1.4.18"</code> |
-| <a id="m4_register_toolchains-extra_copts"></a>extra_copts |  Additional C compiler options to use when building GNU M4.   |  <code>[]</code> |
-
-
-<a id="m4_toolchain"></a>
-
-## m4_toolchain
-
-<pre>
-m4_toolchain(<a href="#m4_toolchain-ctx">ctx</a>)
-</pre>
-
-Returns the current [`M4ToolchainInfo`](#M4ToolchainInfo).
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="m4_toolchain-ctx"></a>ctx |  A rule context, where the rule has a toolchain dependency on [<code>M4_TOOLCHAIN_TYPE</code>](#M4_TOOLCHAIN_TYPE).   |  none |
-
-**RETURNS**
-
-An [`M4ToolchainInfo`](#M4ToolchainInfo).
+| <a id="m4_toolchain_repository-m4_repository"></a>m4_repository |  The name of an [`m4_repository`](#m4_repository).   | String | required |  |
+| <a id="m4_toolchain_repository-repo_mapping"></a>repo_mapping |  In `WORKSPACE` context only: a dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.<br><br>For example, an entry `"@foo": "@bar"` declares that, for any time this repository depends on `@foo` (such as a dependency on `@foo//some:target`, it should actually resolve that dependency within globally-declared `@bar` (`@bar//some:target`).<br><br>This attribute is _not_ supported in `MODULE.bazel` context (when invoking a repository rule inside a module extension's implementation function).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  |
 
 

--- a/m4/internal/BUILD
+++ b/m4/internal/BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 filegroup(
     name = "bzl_srcs",
     srcs = glob([

--- a/m4/internal/toolchain_info.bzl
+++ b/m4/internal/toolchain_info.bzl
@@ -44,7 +44,7 @@ m4_toolchain_info = rule(
         "m4_tool": attr.label(
             mandatory = True,
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "m4_env": attr.string_dict(),
     },

--- a/m4/rules/m4.bzl
+++ b/m4/rules/m4.bzl
@@ -134,12 +134,12 @@ These will be added to the command args immediately before the source files.
         "_capture_stdout": attr.label(
             executable = True,
             default = Label("//m4/internal:capture_stdout"),
-            cfg = "host",
+            cfg = "exec",
         ),
         "_deny_shell": attr.label(
             executable = True,
             default = Label("//m4/internal:deny_shell"),
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     toolchains = [M4_TOOLCHAIN_TYPE],

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//m4:m4.bzl", "m4")
 
 m4(

--- a/tests/m4_test.cc
+++ b/tests/m4_test.cc
@@ -7,6 +7,12 @@
 using bazel::tools::cpp::runfiles::Runfiles;
 using std::string;
 
+#ifdef _WIN32
+#define PATH_SLASH '\\'
+#else
+#define PATH_SLASH '/'
+#endif
+
 class RulesM4 : public ::testing::Test {
   protected:
     void SetUp() override {
@@ -40,8 +46,9 @@ class RulesM4 : public ::testing::Test {
         string test_binary(test_binary_ptr);
         string test_workspace(test_workspace_ptr);
 
-        size_t slash = test_binary.find_last_of('/');
+        size_t slash = test_binary.find_last_of(PATH_SLASH);
         if (slash == string::npos) {
+            std::cerr << "test_binary: " << test_binary << std::endl;
             EXPECT_NE(slash, string::npos);
             return "";
         }

--- a/tools/stardoc/BUILD
+++ b/tools/stardoc/BUILD
@@ -1,9 +1,19 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 
+# TODO: Required due to https://github.com/bazelbuild/rules_cc/issues/279
+bzl_library(
+    name = "rules_cc_bzl_lib",
+    srcs = ["@rules_cc//cc:bzl_srcs"],
+    deps = [
+        "@rules_cc//cc/common",
+    ],
+)
+
 bzl_library(
     name = "rules_m4_bzl_srcs",
     srcs = ["//m4:bzl_srcs"],
+    deps = [":rules_cc_bzl_lib"],
 )
 
 stardoc(


### PR DESCRIPTION
This accounts for [incompatible_disable_starlark_host_transitions](https://github.com/bazelbuild/bazel/issues/17032) and [incompatible_autoload_externally](https://github.com/bazelbuild/bazel/issues/23043).