### PR TITLE
Add `data` attribute to provide additional files to m4

### DIFF
--- a/docs/rules_m4.md
+++ b/docs/rules_m4.md
@@ -11,7 +11,7 @@ Bazel rules for the m4 macro expander.
 <pre>
 load("@rules_m4//m4:m4.bzl", "m4")
 
-m4(<a href="#m4-name">name</a>, <a href="#m4-srcs">srcs</a>, <a href="#m4-freeze_state">freeze_state</a>, <a href="#m4-m4_options">m4_options</a>, <a href="#m4-output">output</a>, <a href="#m4-reload_state">reload_state</a>)
+m4(<a href="#m4-name">name</a>, <a href="#m4-srcs">srcs</a>, <a href="#m4-data">data</a>, <a href="#m4-freeze_state">freeze_state</a>, <a href="#m4-m4_options">m4_options</a>, <a href="#m4-output">output</a>, <a href="#m4-reload_state">reload_state</a>)
 </pre>
 
 Perform macro expansion to produce an output file.
@@ -38,6 +38,7 @@ m4(
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="m4-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="m4-srcs"></a>srcs |  List of source files to macro-expand.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+| <a id="m4-data"></a>data |  List of additional files to m4.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="m4-freeze_state"></a>freeze_state |  Optional output file for GNU M4 frozen state. Must have extension `.m4f`.   | <a href="https://bazel.build/concepts/labels">Label</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |
 | <a id="m4-m4_options"></a>m4_options |  Additional options to pass to the `m4` command.<br><br>These will be added to the command args immediately before the source files.   | List of strings | optional |  `[]`  |
 | <a id="m4-output"></a>output |  File to write output to. If unset, defaults to the rule name.   | <a href="https://bazel.build/concepts/labels">Label</a>; <a href="https://bazel.build/reference/be/common-definitions#configurable-attributes">nonconfigurable</a> | optional |  `None`  |

--- a/m4/rules/m4.bzl
+++ b/m4/rules/m4.bzl
@@ -29,7 +29,7 @@ def _m4(ctx):
     if stdout == None:
         stdout = ctx.actions.declare_file(ctx.attr.name)
 
-    inputs = list(ctx.files.srcs)
+    inputs = list(ctx.files.srcs) + list(ctx.files.data)
     outputs = [stdout]
 
     args = ctx.actions.args()
@@ -109,6 +109,12 @@ m4(
             doc = """File to write output to. If unset, defaults to the rule
 name.
 """,
+        ),
+        "data": attr.label_list(
+            doc = "List of additional files to m4.",
+            default = [],
+            mandatory = False,
+            allow_files = True,
         ),
         "freeze_state": attr.output(
             doc = """Optional output file for GNU M4 frozen state. Must have


### PR DESCRIPTION
Hey,

thanks a lot for `rules_m4`. It works perfectly!
One thing that I think is missing is the ability to add extra files to expansion:

```starlark
m4(
  name = "foo",
  srcs = ["foo.in.txt"],
  data = glob(["data/*"]),
  m4_options = [
    "-I", "data",
  ],
)
```

Let me know what you think of this.