### PR TITLE
Use BCR version of M4 for bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,10 +12,14 @@ bazel_dep(
     name = "rules_cc",
     version = "0.1.1",
 )
+bazel_dep(
+    name = "m4",
+    version = "1.4.20.bcr.2",
+)
 
 bazel_dep(
     name = "googletest",
-    version = "1.12.1",
+    version = "1.17.0.bcr.2",
     dev_dependency = True,
     repo_name = "com_google_googletest",
 )
@@ -41,9 +45,9 @@ default_toolchain = use_extension(
     "//m4/internal:default_toolchain_ext.bzl",
     "default_toolchain_ext",
 )
-use_repo(default_toolchain, "m4")
+use_repo(default_toolchain, "m4_toolchain")
 
-register_toolchains("@m4//:toolchain")
+register_toolchains("@m4_toolchain//:toolchain")
 
 testutil = use_extension(
     "//m4/internal:testutil_ext.bzl",

--- a/docs/rules_m4.md
+++ b/docs/rules_m4.md
@@ -121,7 +121,7 @@ An [`M4ToolchainInfo`](#M4ToolchainInfo).
 <pre>
 load("@rules_m4//m4:m4.bzl", "m4_repository")
 
-m4_repository(<a href="#m4_repository-name">name</a>, <a href="#m4_repository-extra_copts">extra_copts</a>, <a href="#m4_repository-extra_linkopts">extra_linkopts</a>, <a href="#m4_repository-repo_mapping">repo_mapping</a>, <a href="#m4_repository-version">version</a>)
+m4_repository(<a href="#m4_repository-name">name</a>, <a href="#m4_repository-extra_copts">extra_copts</a>, <a href="#m4_repository-extra_linkopts">extra_linkopts</a>, <a href="#m4_repository-version">version</a>)
 </pre>
 
 Repository rule for GNU M4.
@@ -147,7 +147,6 @@ m4_repository(
 | <a id="m4_repository-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="m4_repository-extra_copts"></a>extra_copts |  Additional C compiler options to use when building GNU M4.   | List of strings | optional |  `[]`  |
 | <a id="m4_repository-extra_linkopts"></a>extra_linkopts |  Additional linker options to use when building GNU M4.   | List of strings | optional |  `[]`  |
-| <a id="m4_repository-repo_mapping"></a>repo_mapping |  In `WORKSPACE` context only: a dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.<br><br>For example, an entry `"@foo": "@bar"` declares that, for any time this repository depends on `@foo` (such as a dependency on `@foo//some:target`, it should actually resolve that dependency within globally-declared `@bar` (`@bar//some:target`).<br><br>This attribute is _not_ supported in `MODULE.bazel` context (when invoking a repository rule inside a module extension's implementation function).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  |
 | <a id="m4_repository-version"></a>version |  A supported version of GNU M4.   | String | required |  |
 
 
@@ -158,7 +157,7 @@ m4_repository(
 <pre>
 load("@rules_m4//m4:m4.bzl", "m4_toolchain_repository")
 
-m4_toolchain_repository(<a href="#m4_toolchain_repository-name">name</a>, <a href="#m4_toolchain_repository-m4_repository">m4_repository</a>, <a href="#m4_toolchain_repository-repo_mapping">repo_mapping</a>)
+m4_toolchain_repository(<a href="#m4_toolchain_repository-name">name</a>, <a href="#m4_toolchain_repository-m4_repository">m4_repository</a>)
 </pre>
 
 Toolchain repository rule for m4 toolchains.
@@ -195,7 +194,6 @@ register_toolchains("@m4//:toolchain")
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="m4_toolchain_repository-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="m4_toolchain_repository-m4_repository"></a>m4_repository |  The name of an [`m4_repository`](#m4_repository).   | String | required |  |
-| <a id="m4_toolchain_repository-repo_mapping"></a>repo_mapping |  In `WORKSPACE` context only: a dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.<br><br>For example, an entry `"@foo": "@bar"` declares that, for any time this repository depends on `@foo` (such as a dependency on `@foo//some:target`, it should actually resolve that dependency within globally-declared `@bar` (`@bar//some:target`).<br><br>This attribute is _not_ supported in `MODULE.bazel` context (when invoking a repository rule inside a module extension's implementation function).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  |
 
 
 

--- a/m4/internal/default_toolchain_ext.bzl
+++ b/m4/internal/default_toolchain_ext.bzl
@@ -14,27 +14,62 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Adds a default `m4_toolchain_repository` for a bzlmod-enabled workspace."""
+"""Adds a default m4 toolchain for a bzlmod-enabled workspace."""
 
-load("//m4/internal:versions.bzl", "DEFAULT_VERSION")
-load("//m4/rules:m4_repository.bzl", "m4_repository")
-load(
-    "//m4/rules:m4_toolchain_repository.bzl",
-    "m4_toolchain_repository",
+_TOOLCHAIN_BUILD = """\
+load("@rules_m4//m4/internal:toolchain_info.bzl", "m4_toolchain_info")
+load("@rules_m4//m4:toolchain_type.bzl", "M4_TOOLCHAIN_TYPE")
+
+m4_toolchain_info(
+    name = "toolchain_info",
+    m4_tool = "{m4_tool}",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "toolchain",
+    toolchain = ":toolchain_info",
+    toolchain_type = M4_TOOLCHAIN_TYPE,
+    visibility = ["//visibility:public"],
+)
+"""
+
+_BIN_BUILD = """\
+alias(
+    name = "m4",
+    actual = "{m4_tool}",
+    visibility = ["//visibility:public"],
+)
+"""
+
+def _m4_bcr_toolchain_repository_impl(ctx):
+    ctx.file("WORKSPACE", "workspace(name = {name})\n".format(
+        name = repr(ctx.name),
+    ))
+    ctx.file("BUILD.bazel", _TOOLCHAIN_BUILD.format(
+        m4_tool = str(ctx.attr.m4_tool),
+    ))
+    ctx.file("bin/BUILD.bazel", _BIN_BUILD.format(
+        m4_tool = str(ctx.attr.m4_tool),
+    ))
+
+_m4_bcr_toolchain_repository = repository_rule(
+    implementation = _m4_bcr_toolchain_repository_impl,
+    attrs = {
+        "m4_tool": attr.label(
+            doc = "Label of the m4 binary provided by the BCR m4 module.",
+            mandatory = True,
+        ),
+    },
 )
 
 def _default_toolchain_ext(module_ctx):
-    m4_repo_name = "m4_v{}".format(DEFAULT_VERSION)
-    m4_repository(
-        name = m4_repo_name,
-        version = DEFAULT_VERSION,
-    )
-    m4_toolchain_repository(
-        name = "m4",
-        m4_repository = "@" + m4_repo_name,
+    _m4_bcr_toolchain_repository(
+        name = "m4_toolchain",
+        m4_tool = "@m4//:m4",
     )
     return module_ctx.extension_metadata(
-        root_module_direct_deps = ["m4"],
+        root_module_direct_deps = ["m4_toolchain"],
         root_module_direct_dev_deps = [],
     )
 


### PR DESCRIPTION
This change updates bzlmod to use the M4 module from the bazel-central-registry. WORKSPACE is unaffected for full backward compatibility.

closes https://github.com/jmillikin/rules_m4/issues/22